### PR TITLE
Add MANIFEST.in to make sure non source code files will be deployed

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include dota2picker/database/**
+include dota2picker/images/**/*
+include dota2picker/parser/**


### PR DESCRIPTION
For non development installs the non source code files won't be installed, in order to fix this
the MANIFEST.in file was added. The MANIFEST.in together with the setting `include_package_data=True` in the setup.py will make sure all non source code files
will be deployed.